### PR TITLE
fix(answer): use answer directly over answer.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ Expand.prototype.getAnswer = function(input, key) {
 };
 
 Expand.prototype.renderAnswer = function() {
-  return this.answer ? colors.cyan(this.answer.name) : null;
+  return this.answer ? colors.cyan(this.answer) : null;
 };
 
 function identity(pos) {


### PR DESCRIPTION
`choice.get` returns a literal https://github.com/enquirer/prompt-choices/blob/master/index.js#L342
So we need to use the value directly over reading the `name` property from it.

The `undefined` is printed coz of this only

<img width="474" alt="screen shot 2018-02-07 at 4 39 02 pm" src="https://user-images.githubusercontent.com/1706381/35913509-e5f8d4ea-0c25-11e8-8fb1-9cb03b88545e.png">
