### PR TITLE
fix(help): do not empty line when displaying help

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,8 @@ Expand.prototype.renderOutput = function() {
       msg += '\n  Answer: ' + this.rl.line;
       if (this.position === -1 && this.rl.line.trim() !== '') {
         msg += colors.red(' (invalid)');
+        this.rl.line = '';
       }
-      this.rl.line = '';
       return msg;
     case 'pending':
     case 'interacted':


### PR DESCRIPTION
When `h` is pressed to see the expanded help, giving an answer always results in `Invalid character`. This PR contains the fix for same.

### Before
![answer-before](https://user-images.githubusercontent.com/1706381/35913862-27b3a382-0c27-11e8-835c-38716382f927.gif)


### After
![answer-after](https://user-images.githubusercontent.com/1706381/35913865-2bcac310-0c27-11e8-8d87-c437d6dde41a.gif)
